### PR TITLE
Agregar método DELETE por ID en la documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ API para la gestión de libros, integrada con OpenLibrary para verificar ISBN y 
    mvn spring-boot:run
    ```
 
-## Documentación de la API
+# Documentación de la API
 | Método | Endpoint       | Descripción                |
-   |--------|----------------|----------------------------|
+|--------|----------------|----------------------------|
 | GET    | `/books`       | Devuelve todos los libros  |
 | POST   | `/books`       | Agregar un nuevo libro     |
 | GET    | `/books/{id}`  | Devuelve un libro por ID   |
+| DELETE | `/books/{id}`  | Elimina un libro por ID    |
 
 ## Licencia
 Este proyecto está bajo la Licencia MIT.


### PR DESCRIPTION
Este Pull Request actualiza la tabla de documentación de la API en el archivo `README.md` para incluir el método **DELETE** con el siguiente endpoint:

* DELETE /books/{id}: Permite eliminar un libro por su ID.

**Cambios realizados:**
- Se añadió una nueva fila en la tabla de la sección "Documentación de la API" en el archivo README.md
- Se describe el propósito del método DELETE y su funcionalidad.
