### PR TITLE
Agregar método PUT en la documentación del API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ API para la gestión de libros, integrada con OpenLibrary para verificar ISBN y 
    mvn spring-boot:run
    ```
 
-# Documentación de la API
-| Método | Endpoint       | Descripción                |
-|--------|----------------|----------------------------|
-| GET    | `/books`       | Devuelve todos los libros  |
-| POST   | `/books`       | Agregar un nuevo libro     |
-| GET    | `/books/{id}`  | Devuelve un libro por ID   |
-| DELETE | `/books/{id}`  | Elimina un libro por ID    |
-
+## Documentación de la API
+| Método | Endpoint       | Descripción                         |
+|--------|----------------|-------------------------------------|
+| GET    | `/books`       | Devuelve todos los libros           |
+| POST   | `/books`       | Agregar un nuevo libro              |
+| GET    | `/books/{id}`  | Devuelve un libro por ID            |
+| PUT    | `/books/{id}`  | Actualiza un libro existente por ID |
+| DELETE | `/books/{id}`  | Elimina un libro por ID             |
 ## Licencia
 Este proyecto está bajo la Licencia MIT.


### PR DESCRIPTION
Este Pull Request actualiza la documentación de la API en el archivo `README.md` para incluir el método **PUT**.

#### **Detalles del cambio:**
- Se agregó una nueva entrada en la tabla de `README.md` para el método **PUT**:
    - **PUT `/books/{id}`**: Permite actualizar un libro existente por su ID.

Con esto, ahora la documentación refleja todos los endpoints disponibles en el controlador.
